### PR TITLE
chore: fix bazel path in synth.py

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -31,7 +31,7 @@ for version in versions:
     library = gapic.py_library(
         service="osconfig",
         version=version,
-        bazel_target=f"//google/cloud/osconfig/{version}/:osconfig-{version}-py"
+        bazel_target=f"//google/cloud/osconfig/{version}:osconfig-{version}-py"
     )
 
     s.move(library, excludes=["nox.py", "setup.py", "README.rst", "docs/index.rst"])


### PR DESCRIPTION
Fixes #36 

```
2021-01-15 21:54:28,299 synthtool > Failed executing bazel --max_idle_secs=240 build //google/cloud/osconfig/v1/:osconfig-v1-py:

Loading: 
Loading: 0 packages loaded
DEBUG: /usr/local/google/home/busunkim/.cache/bazel/_bazel_busunkim/cbcc59b865d4caa7f44452adb6a37956/external/rules_python/python/pip.bzl:61:10: DEPRECATED: the pip_repositories rule has been replaced with pip_install, please see rules_python 0.1 release notes
ERROR: Skipping '//google/cloud/osconfig/v1/:osconfig-v1-py': The package part of '//google/cloud/osconfig/v1/:osconfig-v1-py' should not end in a slash
WARNING: Target pattern parsing failed.
ERROR: The package part of '//google/cloud/osconfig/v1/:osconfig-v1-py' should not end in a slash
INFO: Elapsed time: 0.372s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
FAILED: Build did NOT complete successfully (0 packages loaded)
```

To test locally, do `python3 -m synthtool` from the root of the repository.