### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,6 @@
     "repo": "googleapis/python-os-config",
     "distribution_name": "google-cloud-os-config",
     "api_id": "osconfig.googleapis.com",
-    "default_version": "",
+    "default_version": "v1",
     "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,6 +9,7 @@
     "library_type": "GAPIC_AUTO",
     "repo": "googleapis/python-os-config",
     "distribution_name": "google-cloud-os-config",
-    "api_id": "osconfig.googleapis.com"
-  }
-  
+    "api_id": "osconfig.googleapis.com",
+    "default_version": "",
+    "codeowner_team": ""
+}


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114