### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "osconfig",
     "name_pretty": "OS Config",
     "product_documentation": "https://cloud.google.com/compute/docs/osconfig/",
-    "client_documentation": "https://googleapis.dev/python/osconfig/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/osconfig/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ patch compliance, and configuration management on VM instances.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-os-config.svg
    :target: https://pypi.org/project/google-cloud-os-config/
 .. _Cloud OS Config API: https://cloud.google.com/compute/docs/manage-os
-.. _Client Library Documentation: https://googleapis.dev/python/osconfig/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/osconfig/latest
 .. _Product Documentation:  https://cloud.google.com/compute/docs/manage-os
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.